### PR TITLE
Add couch_stats:reload()

### DIFF
--- a/src/couch_stats.erl
+++ b/src/couch_stats.erl
@@ -16,6 +16,7 @@
     start/0,
     stop/0,
     fetch/0,
+    reload/0,
     sample/1,
     new/2,
     delete/1,
@@ -39,6 +40,9 @@ stop() ->
 
 fetch() ->
     couch_stats_aggregator:fetch().
+
+reload() ->
+    couch_stats_aggregator:reload().
 
 -spec sample(any()) -> stat().
 sample(Name) ->

--- a/src/couch_stats_aggregator.erl
+++ b/src/couch_stats_aggregator.erl
@@ -16,7 +16,8 @@
 
 -export([
     fetch/0,
-    flush/0
+    flush/0,
+    reload/0
 ]).
 
 -export([
@@ -43,6 +44,9 @@ fetch() ->
 flush() ->
     gen_server:call(?MODULE, flush).
 
+reload() ->
+    gen_server:call(?MODULE, reload).
+
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -59,6 +63,9 @@ handle_call(fetch, _from, #st{stats = Stats}=State) ->
     {reply, {ok, Stats}, State};
 handle_call(flush, _From, State) ->
     {reply, ok, collect(State)};
+handle_call(reload, _from, #st{stats = Stats}=State) ->
+    {ok, Descriptions} = reload_metrics(),
+    {reply, ok, State#st{descriptions=Descriptions}};
 handle_call(Msg, _From, State) ->
     {stop, {unknown_call, Msg}, error, State}.
 


### PR DESCRIPTION
Since couch_stats relies on application:loaded_applications/0 we need a
way to force reload of metrics' definitions. Ability to force reload is
used from a test suite to make sure we have all metrics' definitions
prior to test invocation.

COUCHDB-2540