### PR TITLE
Switching variable names for `couch_stats_process_tracker:track/2`

### DIFF
--- a/src/couch_stats_process_tracker.erl
+++ b/src/couch_stats_process_tracker.erl
@@ -37,8 +37,8 @@ track(Name) ->
     track(self(), Name).
 
 -spec track(pid(), any()) -> ok.
-track(Name, Pid) ->
-    gen_server:cast(?MODULE, {track, Name, Pid}).
+track(Pid, Name) ->
+    gen_server:cast(?MODULE, {track, Pid, Name}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).


### PR DESCRIPTION
It seems that `couch_stats_process_tracker:track/2` has the variables `Name` and `Pid` erroneously switched. This is confusing.